### PR TITLE
turn off static boost to ensure the build process is correct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(BUILD_INTERFACE_CSHARP "Build interface for C#" ON)
 # Find dependencies
 # ===================================================
 # Boost
-option(WITH_BOOST_STATIC "Boost static libraries" ON)
+option(WITH_BOOST_STATIC "Boost static libraries" OFF)
 set(Boost_USE_STATIC_LIBS ${WITH_BOOST_STATIC})
 set(BOOST_ALL_DYN_LINK NOT ${WITH_BOOST_STATIC})
 if(WIN32)


### PR DESCRIPTION
Or else I face the following error:

/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/5/../../../x86_64-linux-gnu/libboost_filesystem.a(operations.o): relocat
ion R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/lib/gcc/x86_64-linux-gnu/5/../../../x86_64-linux-gnu/libboost_filesystem.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status